### PR TITLE
Full PDO : Move mysql to pdo driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ abbandoned there, a fork is created and further developed.
 System requirements
 -------------------
 * PHP 5.2.0 or greater;
-* PHP extensions: php_mysql (MySQL version), php_pdo and php_pdo_sqlite (SQLite version).
+* PHP extensions: php_pdo, php_pdo_mysql (MySQL version), php_pdo_sqlite (SQLite version).
 Tested browsers:
 * Internet Explorer 8
 * Firefox v3.6, v4


### PR DESCRIPTION
Hello,

In order to remove usage of deprecated mysql driver on PHP 5.5 and PHP 7.

I use Sqlite3 class and adapt it to Mysql PDO.

Best regards,
Memiks.
